### PR TITLE
n2sn config

### DIFF
--- a/configs/n2sn.yml
+++ b/configs/n2sn.yml
@@ -1,0 +1,7 @@
+docker_image: "quay.io/condaforge/linux-anvil-comp7:latest"
+env_name: "n2sn"
+python_version: "3.9"
+pkg_name: "n2snusertools"
+pkg_version: "0.3.6"
+extra_packages: ""
+channels: "-c nsls2forge -c defaults"


### PR DESCRIPTION
## Revision in the gist:
- https://gist.github.com/mrakitin/10103ef72dfb0ae78fdd99efefd59d70/50a605b2f1ce83c405befb19b809ded860d46fd1

## Result of execution:
```bash
$ python ../conda-pack-template/render.py
Script location: /Users/mrakitin/tmp/docker-build/conda-pack-template
#!/bin/bash

# To be run as:
# $ docker run -it --rm -v $PWD:/build quay.io/condaforge/linux-anvil-comp7:latest bash /build/gen-conda-packed-env-n2sn.sh

set -e

umask 0002

. /opt/conda/etc/profile.d/conda.sh

conda install conda -y

env_name="n2sn"
python_version="=3.9"
pkg="n2snusertools=0.3.6"
extra_packages=""
channels="-c nsls2forge -c defaults"

time conda create \
    -n ${env_name} \
    ${channels} --override-channels -y \
    python${python_version} conda-pack \
    ${pkg} \
    ${extra_packages}

conda activate ${env_name}

time conda env export \
    -n ${env_name} \
    -f /build/${env_name}.yml \
    ${channels} --override-channels

# Assuming the "build" dir is mounted via the "docker run -v ..."
time conda-pack -o /build/${env_name}.tar.gz

time openssl sha256 /build/${env_name}.tar.gz > /build/${env_name}-sha256sum.txt
chmod -v 664 /build/${env_name}.*

conda deactivate

```